### PR TITLE
Require libledmtx built with `ENABLE_VIEWPORT` enabled

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -24,6 +24,11 @@
 #include <ledmtx_core.h>
 #include <ledmtx_font5x7.h>
 #include <ledmtx_stdio.h>
+#if LEDMTX_HAVE_VIEWPORT != 1
+#error p18clock requires a libledmtx build that has ENABLE_VIEWPORT=1
+
+#endif
+
 #include <signal.h>
 #include <stdio.h>
 // clang-format on


### PR DESCRIPTION
Per pull request #4, p18clock now requires a libledmtx build that has `ENABLE_VIEWPORT == 1`.  Complain if libledmtx does not support changing display viewport.