### PR TITLE
Apply minor fixes and bump version to 1.0.0

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -74,9 +74,9 @@
                            // configured as general purpose I/O
 
 /* The IDLOC0, IDLOC1, and IDLOC2 bytes store the firmware version */
-__CONFIG(__IDLOC0, 0);
-__CONFIG(__IDLOC1, 2);
-__CONFIG(__IDLOC2, 2);
+__CONFIG(__IDLOC0, 1);
+__CONFIG(__IDLOC1, 0);
+__CONFIG(__IDLOC2, 0);
 
 #define UNDEF ((unsigned char)-1)
 


### PR DESCRIPTION
This pull request fixes misbehavior in scheduled actions under certain circumstances.  This was visible, e.g. in AUTO mode, where a vertical scroll is scheduled every 5 minutes; if `_time.min` was near wrap-around, vertical scroll was executed continuously.

Additionally, bump version to 1.0.0.