### PR TITLE
Accommodate latest p18clock hardware updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ $ # Generate `p18clock.hex`; the image can be flashed into the MCU via pk2cmd
 $ make P18CLOCK_LANG=EN # or `P18CLOCK_LANG=ES` to use Spanish translation
 ```
 
+Additional arguments can be passed to `make` in order to enable/disable specific features; specifically,
+- `LARGE_DISPLAY=1`: build for latest p18clock hardware (builtin 40x8 display).
+- `REVERSE_PUSHB_ORDER=1`: define if the PCB has push buttons laid out in reverse order.
+
 ## Hardware
 ![p18clock hardware](doc/hardware.jpg)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,9 +1,10 @@
 CC = sdcc
+ifdef P18F2550
 P18FXXX = 18f2550
-
-# 32x7 display @ 50 Hz (given a Fosc of 8 MHz for the primary oscillator)
+else
+P18FXXX = 18f2510
+endif
 OSC_HZ = 8000000
-VIDEO_MODE_DESC = 32 31 7 50
 
 # Set `INSTALL_PREFIX` to actual libledmtx installation directory.
 INSTALL_PREFIX = $(HOME)/.local/libledmtx/
@@ -25,6 +26,21 @@ CFLAGS = -mpic16 -p$(P18FXXX) --fomit-frame-pointer --pstack-model=small --use-n
 
 OBJECTS += rbuf.o lm35.o main.o
 P18CLOCK_LANG?=EN
+
+# `LARGE_DISPLAY`: define to assume builtin display of 40x8.
+ifdef LARGE_DISPLAY
+# 40x8 display @ 50 Hz; framebuffer can hold up to four lines of text though
+VIDEO_MODE_DESC = 40 35 8 50
+CFLAGS += -D__P18CLOCK_LARGE_DISPLAY
+else
+# 32x7 display @ 50 Hz; framebuffer can hold up to four lines of text though
+VIDEO_MODE_DESC = 32 31 7 50
+endif
+
+# `REVERSE_PUSHB_ORDER`: define if the PCB has push buttons laid out in reverse order.
+ifdef REVERSE_PUSHB_ORDER
+CFLAGS += -D__P18CLOCK_REVERSE_PUSHB_ORDER
+endif
 
 all: ledmtx_modegen_modes.h p18clock.hex
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -30,11 +30,11 @@ P18CLOCK_LANG?=EN
 # `LARGE_DISPLAY`: define to assume builtin display of 40x8.
 ifdef LARGE_DISPLAY
 # 40x8 display @ 50 Hz; framebuffer can hold up to four lines of text though
-VIDEO_MODE_DESC = 40 35 8 50
+VIDEO_MODE_DESC = 40 35 8 100
 CFLAGS += -D__P18CLOCK_LARGE_DISPLAY
 else
 # 32x7 display @ 50 Hz; framebuffer can hold up to four lines of text though
-VIDEO_MODE_DESC = 32 31 7 50
+VIDEO_MODE_DESC = 32 31 7 100
 endif
 
 # `REVERSE_PUSHB_ORDER`: define if the PCB has push buttons laid out in reverse order.

--- a/src/Makefile
+++ b/src/Makefile
@@ -32,6 +32,7 @@ ifdef LARGE_DISPLAY
 # 40x8 display @ 50 Hz; framebuffer can hold up to four lines of text though
 VIDEO_MODE_DESC = 40 35 8 100
 CFLAGS += -D__P18CLOCK_LARGE_DISPLAY
+O += font6x8
 else
 # 32x7 display @ 50 Hz; framebuffer can hold up to four lines of text though
 VIDEO_MODE_DESC = 32 31 7 100

--- a/src/main.c
+++ b/src/main.c
@@ -503,10 +503,10 @@ static unsigned char _state = STATE_TIME;
 
 /// A single descriptor (and NUL-terminated string) is used for scrolling text.
 static char _tmpstr[64];
-static struct ledmtx_scrollstr_desc _scroll_desc = {1,
-                                                    1,
+static struct ledmtx_scrollstr_desc _scroll_desc = {2,
+                                                    2,
                                                     ledmtx_scrollstr_step,
-                                                    7,
+                                                    LEDMTX_VIEWPORT_HEIGHT,
                                                     LEDMTX__DEFAULT_WIDTH,
                                                     0,
                                                     0,
@@ -897,7 +897,7 @@ void main(void) {
     }
 
     if (++rcounter == 0) {
-      rcounter = 0xa8; // Should overflow in roughly 0.25s
+      rcounter = 0x51; // Should overflow in roughly 0.25s
       _state_fn[_state](MESSAGE_CLASS(c), NULL);
     }
     c = rbuf_get(_mbuf);


### PR DESCRIPTION
This pull request applies the required changes to accommodate the latest p18clock hardware.  In particular,

- Latest p18clock hardware is based on a PIC18F2510 and a r393c164-based 40x8 display.  Specifically, act on the following `make` variables [1]:
    * `P18F2550`: if defined, build for the PIC18F2550.
    * `LARGE_DISPLAY`: define to build for a 40x8 display; if undefined, build for legacy 32x7 display.
    * `REVERSE_PUSHB_ORDER`: define if the PCB has push buttons laid out in reverse order.
- Default to 100Hz refresh rate.
- Use a 6x8 font in main modes (only if built with `LARGE_DISPLAY=1`).

[1] `README.md` has been updated accordingly.