### PR TITLE
Redraw alarm indicator only if needed

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -90,9 +90,9 @@
                            // configured as general purpose I/O
 
 /* The IDLOC0, IDLOC1, and IDLOC2 bytes store the firmware version */
-__CONFIG(__IDLOC0, 1);
+__CONFIG(__IDLOC0, 2);
 __CONFIG(__IDLOC1, 0);
-__CONFIG(__IDLOC2, 1);
+__CONFIG(__IDLOC2, 2);
 
 #define UNDEF ((unsigned char)-1)
 

--- a/src/main.c
+++ b/src/main.c
@@ -903,7 +903,7 @@ static state_func_t __code _state_fn[] = {
     S_alarm_sethour, S_alarm_setmin};
 
 void main(void) {
-  static char c;
+  static signed char c;
   static unsigned char rcounter = 0xff;
   static unsigned char temp_measurement_sched_sec = UNDEF;
 

--- a/src/main.c
+++ b/src/main.c
@@ -615,8 +615,12 @@ void S_time(char arg, __data char *input) /* __wparam */
     LEDMTX_HOME();
     printf(ALTERNATE("%02hu %02hu", "%02hu:%02hu"), _time.hour, _time.min);
 #if defined(__P18CLOCK_LARGE_DISPLAY)
-    ledmtx_putchar(LEDMTX_PUTCHAR_CPY, /*mask=*/0xfc, /*x=*/34, /*y=*/0,
-                   _alarm.ena ? 0x17 : 0x20);
+    static unsigned char alarm_was_enabled = 0;
+    if (_alarm.ena != alarm_was_enabled) {
+      ledmtx_putchar(LEDMTX_PUTCHAR_CPY, /*mask=*/0xfc, /*x=*/34, /*y=*/0,
+                     _alarm.ena ? 0x17 : 0x20);
+      alarm_was_enabled = _alarm.ena;
+    }
 #endif
   } else if (*input == B_MODE) {
     _state = STATE_DATE;


### PR DESCRIPTION
Redraw alarm indicator in `S_time()` only if needed.  Bump p18clock version to 2.0.2.