### PR TITLE
Fix (lack of) alarm indicator redraw

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -611,11 +611,13 @@ void idle_alarm(void) {
 /* __wparam uncompatible with function pointers */
 void S_time(char arg, __data char *input) /* __wparam */
 {
+#if defined(__P18CLOCK_LARGE_DISPLAY)
+  static unsigned char alarm_was_enabled = UNDEF;
+#endif
   if (input == (__data char *)NULL) {
     LEDMTX_HOME();
     printf(ALTERNATE("%02hu %02hu", "%02hu:%02hu"), _time.hour, _time.min);
 #if defined(__P18CLOCK_LARGE_DISPLAY)
-    static unsigned char alarm_was_enabled = 0;
     if (_alarm.ena != alarm_was_enabled) {
       ledmtx_putchar(LEDMTX_PUTCHAR_CPY, /*mask=*/0xfc, /*x=*/34, /*y=*/0,
                      _alarm.ena ? 0x17 : 0x20);
@@ -623,6 +625,9 @@ void S_time(char arg, __data char *input) /* __wparam */
     }
 #endif
   } else if (*input == B_MODE) {
+#if defined(__P18CLOCK_LARGE_DISPLAY)
+    alarm_was_enabled = UNDEF;
+#endif
     _state = STATE_DATE;
 
     sprintf(_tmpstr, "  %s", _str_state[_state]);


### PR DESCRIPTION
Under certain circumstances, the alarm indicator may not be redrawn appropriately if the `S_time` main state was entered again from any other state.

A simple fix is to reset `alarm_was_enabled` when leaving `S_time()`.