### PR TITLE
A couple of (very minor) UI improvements

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -506,7 +506,7 @@ char day_of_week(unsigned char mday, unsigned char mon, unsigned int year) {
 #define STATE_ALARM_SETMIN 0x0d
 
 /// The current state of the FSM
-static unsigned char _state = STATE_TIME;
+static unsigned char _state = STATE_TIME_SETHOUR;
 
 /// A single descriptor (and NUL-terminated string) is used for scrolling text.
 static char _tmpstr[64];
@@ -764,6 +764,7 @@ void S_time_sethour(char arg, __data char *input) /* __wparam */
   if (input == (__data char *)NULL) {
     LEDMTX_HOME();
     printf(ALTERNATE("  :", "%02hu:"), _time.hour);
+    printf("%02hu", _time.min);
   } else if (*input == B_SET) {
     _state = STATE_TIME_SETMIN;
 

--- a/src/main.c
+++ b/src/main.c
@@ -92,7 +92,7 @@
 /* The IDLOC0, IDLOC1, and IDLOC2 bytes store the firmware version */
 __CONFIG(__IDLOC0, 2);
 __CONFIG(__IDLOC1, 0);
-__CONFIG(__IDLOC2, 2);
+__CONFIG(__IDLOC2, 3);
 
 #define UNDEF ((unsigned char)-1)
 


### PR DESCRIPTION
This PR introduces a couple of very minor user interface improvements; specifically, it

- Move alarm-enabled indicator logic to `__S_time_draw_alarm_indicator()`.  As a side effect, this fixes redraw when transitioning from static (time only) `S_auto` to `S_time`.
- Enter `S_time_sethour()` instead upon boot.

Additionally, bump version to 2.0.3.