### PR TITLE
(Partial) fix switch debounce

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -29,12 +29,12 @@ P18CLOCK_LANG?=EN
 
 # `LARGE_DISPLAY`: define to assume builtin display of 40x8.
 ifdef LARGE_DISPLAY
-# 40x8 display @ 50 Hz; framebuffer can hold up to four lines of text though
+# 40x8 display @ 100 Hz; framebuffer can hold up to four lines of text (35px)
 VIDEO_MODE_DESC = 40 35 8 100
 CFLAGS += -D__P18CLOCK_LARGE_DISPLAY
 O += font6x8
 else
-# 32x7 display @ 50 Hz; framebuffer can hold up to four lines of text though
+# 32x7 display @ 100 Hz; framebuffer can hold up to four lines of text (31px)
 VIDEO_MODE_DESC = 32 31 7 100
 endif
 

--- a/src/main.c
+++ b/src/main.c
@@ -92,7 +92,7 @@
 /* The IDLOC0, IDLOC1, and IDLOC2 bytes store the firmware version */
 __CONFIG(__IDLOC0, 2);
 __CONFIG(__IDLOC1, 0);
-__CONFIG(__IDLOC2, 3);
+__CONFIG(__IDLOC2, 4);
 
 #define UNDEF ((unsigned char)-1)
 

--- a/src/main.c
+++ b/src/main.c
@@ -289,7 +289,7 @@ SIGHANDLERNAKED(_tmr1_handler)
 }
 // clang-format on
 
-#define INT0_UNMASK_TIMEOUT 7
+#define INT0_UNMASK_TIMEOUT 14
 /// INT0 interrupt is externally triggered on RB0/INT0 pin.  RB0:RB3 is
 /// (indirectly) driven by push buttons, and thus requires some debouncing
 /// logic. In particular, `_int0_handler` masks INT0 interrupts for some


### PR DESCRIPTION
Commit [38d34c70d9d7fc6cc6bbb16ad4376f58a92ef3b5](https://github.com/jalopezg-git/p18clock/commit/38d34c70d9d7fc6cc6bbb16ad4376f58a92ef3b5) updated refresh rate to 100 Hz.  However, given that INT0 unmasking is carried out in TMR0 ISR, `INT0_UNMASK_TIMEOUT` also needed updating.

Fix it and bump p18clock version to 2.0.4.