### PR TITLE
Improve input handling

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -380,6 +380,7 @@ SIGHANDLERNAKED(_tmr2_handler)
   retfie	1
 
 @tmr2__stop:
+  bcf		_INTCON2, 6, 0		; restore INTEDG0 (falling edge)
   bcf		_T2CON, 2, 0
   retfie	1
   __endasm;


### PR DESCRIPTION
This pull-request improves the handling of user input.  Specifically, it

- Moves keystroke re-queueing from Timer3 to Timer2.  Timer2 is now used for both CCP1/PWM and keystroke repetition (see comments in source code).  Timer3 is left unused / reserved for future use for `libledmtx/r393c164` (see [here](https://github.com/jalopezg-git/libledmtx/pull/20)).
- Restore `INTEDG0` to falling edge at end of keystroke repetition.  This fixes input issue where `INTEDG0` was sometimes left to 1 (Interrupt on rising edge).  Make sure it is always restored to `0` in Timer2 ISR.