### PR TITLE
Enable libledmtx `r393c164` brightness adjustment if in a main state (experimental)

### DIFF
--- a/src/ledmtx_r393c164.inc
+++ b/src/ledmtx_r393c164.inc
@@ -8,3 +8,26 @@ LEDMTX_R393C164_RRST	equ	RA2
 LEDMTX_R393C164_RENA	equ	RA3
 LEDMTX_R393C164_CCLK	equ	RA5
 LEDMTX_R393C164_CDAT	equ	RA4
+
+; Uncomment to enable experimental software-based PWM for brightness adjustment
+; (requires an additional timer module; defaults to Timer3).
+#define LEDMTX_R393C164_E_SOFTPWM 1
+
+#ifdef LEDMTX_R393C164_E_SOFTPWM
+  global ___ledmtx_r393c164_E_softpwm_tmr3
+.udata_ledmtx_driver	udata
+___ledmtx_r393c164_E_softpwm_tmr3	res	2
+
+LEDMTX_R393C164_E_SOFTPWM_DUTY_BEGIN	macro
+  movff	___ledmtx_r393c164_E_softpwm_tmr3+1, TMR3H
+  movff	___ledmtx_r393c164_E_softpwm_tmr3+0, TMR3L
+  bsf		T3CON, TMR3ON, A
+  endm
+
+LEDMTX_R393C164_E_SOFTPWM_DUTY_END	macro
+  bcf		PIR2, TMR3IF, A
+  bcf		LEDMTX_R393C164_IOPORT, LEDMTX_R393C164_RENA, A
+  bcf		T3CON, TMR3ON, A
+  retfie
+  endm
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -93,8 +93,8 @@ extern void __ledmtx_r393c164_E_softpwm_duty_end;
 
 /* The IDLOC0, IDLOC1, and IDLOC2 bytes store the firmware version */
 __CONFIG(__IDLOC0, 2);
-__CONFIG(__IDLOC1, 0);
-__CONFIG(__IDLOC2, 4);
+__CONFIG(__IDLOC1, 1);
+__CONFIG(__IDLOC2, 0);
 
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof(x[0]))
 #define UNDEF ((unsigned char)-1)


### PR DESCRIPTION
 If `_state` is a main state, enable `B_UP` / `B_DOWN` to adjust display brightness.  This feature is highly experimental and may still have bugs.