### PR TITLE
[hardware] Fix errata in XTAL capacitor values

### DIFF
--- a/hardware/kicad/p18clock/p18clock.kicad_pcb
+++ b/hardware/kicad/p18clock/p18clock.kicad_pcb
@@ -248,7 +248,7 @@
 				)
 			)
 		)
-		(property "Value" "12pF"
+		(property "Value" "22pF"
 			(at 0 1.85 90)
 			(layer "F.Fab")
 			(uuid "c3501094-8583-4cac-af48-b1c167ff8479")
@@ -12181,7 +12181,7 @@
 				)
 			)
 		)
-		(property "Value" "12pF"
+		(property "Value" "22pF"
 			(at 0 1.85 90)
 			(layer "F.Fab")
 			(uuid "ee0b477f-f250-4af8-8422-dac72649c4d9")
@@ -13633,7 +13633,7 @@
 				)
 			)
 		)
-		(property "Value" "22pF"
+		(property "Value" "12pF"
 			(at 0 1.85 90)
 			(layer "F.Fab")
 			(uuid "334dd097-a916-477a-b1ff-984d923aec7e")
@@ -29892,7 +29892,7 @@
 				)
 			)
 		)
-		(property "Value" "22pF"
+		(property "Value" "12pF"
 			(at 0 1.85 90)
 			(layer "F.Fab")
 			(uuid "4584ceb8-e7ec-48d6-a41a-3cef7fb4ad42")

--- a/hardware/kicad/p18clock/p18clock.kicad_sch
+++ b/hardware/kicad/p18clock/p18clock.kicad_sch
@@ -7573,7 +7573,7 @@
 				(justify right)
 			)
 		)
-		(property "Value" "12pF"
+		(property "Value" "22pF"
 			(at 121.92 54.6162 0)
 			(effects
 				(font
@@ -7923,7 +7923,7 @@
 				(justify right)
 			)
 		)
-		(property "Value" "22pF"
+		(property "Value" "12pF"
 			(at 137.16 156.2162 0)
 			(effects
 				(font
@@ -8799,7 +8799,7 @@
 				(justify right)
 			)
 		)
-		(property "Value" "22pF"
+		(property "Value" "12pF"
 			(at 144.78 156.2162 0)
 			(effects
 				(font
@@ -9501,7 +9501,7 @@
 				(justify right)
 			)
 		)
-		(property "Value" "12pF"
+		(property "Value" "22pF"
 			(at 129.54 54.6162 0)
 			(effects
 				(font


### PR DESCRIPTION
Swap XTAL capacitors (8MHz should be 12-15pF; 32.768kHz should be 20-22pF).

Closes #23.